### PR TITLE
Reverse mapping: uses real Polymer splice but emulates backbone add

### DIFF
--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -14,43 +14,7 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
     });
   };
 
-  var splicesObject = this.models;
-
-  var addNotify = function(model) {
-    var ix = indexOf(model);
-
-    // https://www.polymer-project.org/1.0/docs/devguide/properties.html#array-observation
-    var change = {keySplices:[], indexSplices:[]};
-    change.keySplices.push({
-      index: ix,
-      removed: [],
-      removedItems: [],
-      added: [ix]
-    });
-    change.indexSplices.push({
-      index: ix,
-      addedCount: 1,
-      removed: [],
-      object: splicesObject,
-      type: 'splice',
-      addedKeys: [ix]
-    });
-
-    element.notifyPath(pathPrefix + '.models.splices', change);
-
-    // remove this timeout and the rendered element goes blank
-    window.setTimeout(function() {
-      // TODO would it be possible to notify .* here?
-      for (var attribute in model.attributes) {
-        // we could reuse code with modelSetup here
-        var value = model.get(attribute);
-        element.notifyPath(pathPrefix + '.models.' + ix + '.attributes.' + attribute, value);
-      }
-    }, 1);
-  };
-
   this.each(modelSetup.bind(this));
-  this.on('add', addNotify.bind(this));
   this.on('add', modelSetup.bind(this));
 };
 

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -16,17 +16,28 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
 
   this.each(modelSetup.bind(this));
 
+  // override Backbone add
   var _add = this.add;
-  this.add = function(models, options) {
-    if (typeof models.length !== 'undefined') {
+  var addOptions = {add: true, remove: false}; // from backbone source
+  this.add = function(model, options) {
+    if (_.isArray(model)) {
       throw new Error('backbone-polymer only accepts add of single model');
     }
     // we should probably operate on the Collection.set level to be more allowing
-    if (!this._isModel(models)) {
+    if (!this._isModel(model)) {
       throw new Error('backbone-polymer requires model instances, not just attributes');
     }
 
-    modelSetup.bind(models);
+    var options = _.extend({merge: false}, options, addOptions);
+    var ix = options.at || 0;
+
+    element.splice(pathPrefix + '.models', ix, 0, [model]);
+    if (!options.silent) {
+      this.trigger('add', model, this, options);
+    }
+
+    modelSetup.bind(model);
+    return model;
   };
 };
 

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -15,7 +15,19 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
   };
 
   this.each(modelSetup.bind(this));
-  this.on('add', modelSetup.bind(this));
+
+  var _add = this.add;
+  this.add = function(models, options) {
+    if (typeof models.length !== 'undefined') {
+      throw new Error('backbone-polymer only accepts add of single model');
+    }
+    // we should probably operate on the Collection.set level to be more allowing
+    if (!this._isModel(models)) {
+      throw new Error('backbone-polymer requires model instances, not just attributes');
+    }
+
+    modelSetup.bind(models);
+  };
 };
 
 if (typeof module !== 'undefined') {

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -40,7 +40,7 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
       this.trigger('update', this, options);
     }
 
-    modelSetup.bind(model);
+    modelSetup.call(this, model);
     return model;
   };
 };

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -20,6 +20,8 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
   var _add = this.add;
   var addOptions = {add: true, remove: false}; // from backbone source
   this.add = function(model, options) {
+    this.length = this.length + 1;
+    console.log('add (model)', model, '(options)', options);
     if (_.isArray(model)) {
       throw new Error('backbone-polymer only accepts add of single model');
     }
@@ -31,7 +33,7 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
     var options = _.extend({merge: false}, options, addOptions);
     var ix = options.at || 0;
 
-    element.splice(pathPrefix + '.models', ix, 0, [model]);
+    element.splice(pathPrefix + '.models', ix, 0, model);
     if (!options.silent) {
       this.trigger('add', model, this, options);
     }

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -1,6 +1,5 @@
 
 var BackbonePolymerAttach = function(element, pathPrefix) {
-  console.log('BackbonePolymerAttach', this, element, pathPrefix);
 
   var indexOf = this.indexOf.bind(this);
 
@@ -21,7 +20,6 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
   var addOptions = {add: true, remove: false}; // from backbone source
   this.add = function(model, options) {
     this.length = this.length + 1;
-    console.log('add (model)', model, '(options)', options);
     if (_.isArray(model)) {
       throw new Error('backbone-polymer only accepts add of single model');
     }

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -23,9 +23,11 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
     if (_.isArray(model)) {
       throw new Error('backbone-polymer only accepts add of single model');
     }
-    // we should probably operate on the Collection.set level to be more allowing
     if (!this._isModel(model)) {
       throw new Error('backbone-polymer requires model instances, not just attributes');
+    }
+    if (this.get(model)) {
+      throw new Error('model already exists as' + this.get(model).cid);
     }
 
     var options = _.extend({merge: false}, options, addOptions);

--- a/backbone-polymer-mixin.js
+++ b/backbone-polymer-mixin.js
@@ -27,15 +27,17 @@ var BackbonePolymerAttach = function(element, pathPrefix) {
       throw new Error('backbone-polymer requires model instances, not just attributes');
     }
     if (this.get(model)) {
-      throw new Error('model already exists as' + this.get(model).cid);
+      throw new Error('backbone-polymer model already exists as cid ' + this.get(model).cid);
     }
 
     var options = _.extend({merge: false}, options, addOptions);
     var ix = options.at || 0;
 
     element.splice(pathPrefix + '.models', ix, 0, model);
+    this._addReference(model, options);
     if (!options.silent) {
-      this.trigger('add', model, this, options);
+      model.trigger('add', model, this, options);
+      this.trigger('update', this, options);
     }
 
     modelSetup.bind(model);

--- a/test/backbone-compatibility.html
+++ b/test/backbone-compatibility.html
@@ -1,12 +1,20 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../node_modules/mocha/mocha.js"></script>
+  <script src="../node_modules/web-component-tester/browser.js"></script>
 
-var expect = require('chai').expect;
+  <!-- lib dependencies -->
+  <script src="../node_modules/yobo/node_modules/underscore/underscore.js"></script>
+  <script src="../node_modules/yobo/node_modules/backbone/backbone.js"></script>
+  <script src="../backbone-polymer-mixin.js"></script>
 
-// still undecided on how the mixin gets dependencies
-_ = require('yobo')._;
-
-var Backbone = require('yobo').Backbone;
-
-var BackbonePolymerAttach = require('../backbone-polymer-mixin');
+  <link rel="import" href="../bower_components/polymer/polymer.html">
+</head>
+<body>
+<script>
 
 var PolymerElementMock = function(testArray) {
 
@@ -139,3 +147,7 @@ describe("Array modification through Polymer splices, emulate backbone events", 
     });
   });
 });
+
+</script>
+</body>
+</html>

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -39,9 +39,12 @@ describe("Array modification through Polymer splices, emulate backbone events", 
       var c = new Backbone.Collection();
       c.add({id: 'a2', type: 'testmodel2'});
       c.add({id: 'a3', type: 'testmodel3'});
-      var m = new Backbone.Model({id: 'a1', type: 'testmodel'})
+      var m = new Backbone.Model({id: 'a1', type: 'testmodel'});
       c.on('add', function(model, collection, options) {
         console.log('add', m === model ? '(model)' : model, c === collection ? '(collection)' : collection, JSON.stringify(options));
+      });
+      m.on('add', function(model, collection, options) {
+        console.log('model add', m === model ? '(model)' : model, c === collection ? '(collection)' : collection, JSON.stringify(options));
       });
       var added = c.add(m, {at: 1});
       console.log('add returned', m === added ? '(model)' : model);
@@ -88,20 +91,26 @@ describe("Array modification through Polymer splices, emulate backbone events", 
 
       //Expects on the options obj.
       expect(adds[0].options).to.be.an('object');
-      expect(adds[0].options).to.have.property('add').and.equal(true);
-      expect(adds[0].options).to.have.property('merge').and.equal(false);
-      expect(adds[0].options).to.have.property('remove').and.equal(false);
+      expect(adds[0].options).to.have.property('add').that.equals(true);
+      expect(adds[0].options).to.have.property('merge').that.equals(false);
+      expect(adds[0].options).to.have.property('remove').that.equals(false);
       expect(adds[0].options).to.not.have.property('at');
       expect(adds[0].collection).to.have.property('length').and.equal(1);
 
       var m1 = new Backbone.Model({id: 'add2', type: 'test'});
+      modeladd = [];
+      m1.on('add', function(m, c, o) {
+        modeladd.push({model:m, collection:c, options:o});
+      });
       c.add(m1, {at: 1});
 
       //Adding at an index, expects Options to have 'at'
-      expect(adds[1].options).to.have.property('add').and.equal(true);
-      expect(adds[1].options).to.have.property('at').and.equal(1);
-      expect(adds[0].collection).to.have.property('length').and.equal(2);
+      expect(adds[1].options).to.have.property('add').that.equals(true);
+      expect(adds[1].options).to.have.property('at').that.equals(1);
+      expect(adds[1].collection).to.have.length(2);
       expect(e.spliced).to.have.length(2);
+      expect(modeladd).to.have.length(1);
+      expect(modeladd[0]).to.deep.equal(adds[1]);
 
       //Adding again at index 1, i.e. insert
       var m2 = new Backbone.Model({id: 'add3', type: 'test'});

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -73,6 +73,16 @@ describe("Array modification through Polymer splices, emulate backbone events", 
       }).to.throw(/requires model instance/);
     });
 
+    it("Bails out if the model already exists", function() {
+      expect(function() {
+        var c = new Backbone.Collection();
+        BackbonePolymerAttach.call(c, new PolymerElementMock(), 'edit.units');
+        var m = new Backbone.Model({id: 'add1', type: 'test'});
+        c.add(m);
+        c.add(m);
+      }).to.throw(/Model add blocked because it already exists as cid \d+/);
+    });
+
     it("Is transparent to backbone add event listener", function() {
       var e = new PolymerElementMock();
       var c = new Backbone.Collection();

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -85,6 +85,7 @@ describe("Array modification through Polymer splices, emulate backbone events", 
       expect(adds[0][2]).to.have.property('add').and.equal(true);
       expect(adds[0][2]).to.have.property('merge').and.equal(false);
       expect(adds[0][2]).to.have.property('remove').and.equal(false);
+      expect(adds[0][1]).to.have.property('length').and.equal(1);
 
       var m1 = new Backbone.Model({id: 'add2', type: 'test'});
       c.add(m1, {at: 1});
@@ -92,16 +93,15 @@ describe("Array modification through Polymer splices, emulate backbone events", 
       //Adding at an index, expects Options to have 'at'
       expect(adds[1][2]).to.have.property('add').and.equal(true);
       expect(adds[1][2]).to.have.property('at').and.equal(1);
+      expect(adds[0][1]).to.have.property('length').and.equal(2);
       expect(e.spliced).to.have.length(2);
 
       //Adding again at index 2
       var m2 = new Backbone.Model({id: 'add3', type: 'test'});
       c.add(m2, {at: 2});
-      
+
       expect(e.spliced[2]).to.have.property('index').and.equal(2);
-
+      expect(adds[0][1]).to.have.property('length').and.equal(3);
     });
-
   });
-
 });

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -80,7 +80,7 @@ describe("Array modification through Polymer splices, emulate backbone events", 
         var m = new Backbone.Model({id: 'add1', type: 'test'});
         c.add(m);
         c.add(m);
-      }).to.throw(/Model add blocked because it already exists as cid \d+/);
+      }).to.throw(/backbone-polymer model already exists as cid \w+/);
     });
 
     it("Is transparent to backbone add event listener", function() {

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -1,12 +1,19 @@
 
 var expect = require('chai').expect;
-var BackbonePolymerAttach = require('../backbone-polymer-mixin');
+
+// still undecided on how the mixin gets dependencies
+_ = require('yobo')._;
+
 var Backbone = require('yobo').Backbone;
+
+var BackbonePolymerAttach = require('../backbone-polymer-mixin');
 
 var PolymerElementMock = function() {
 
+  var spliced = this.spliced = [];
+
   this.splice = function(path, index, removeCount, items) {
-    console.log('Polymer got splice', arguments);
+    spliced.push({path: path, index: index, removeCount: removeCount, items: items});
   };
 
   this.notifyPath = function() {
@@ -69,6 +76,7 @@ describe("Array modification through Polymer splices, emulate backbone events", 
       var m = c.add(new Backbone.Model({id: 'add1', type: 'test'}));
       expect(m.get('type')).to.equal('test');
       expect(adds).to.have.length(1);
+      expect(e.spliced).to.have.length(1);
     });
 
   });

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -1,0 +1,60 @@
+
+var expect = require('chai').expect;
+var BackbonePolymerAttach = require('../backbone-polymer-mixin');
+var Backbone = require('yobo').Backbone;
+
+var PolymerElementMock = function() {
+
+  this.splice = function(path, index, removeCount, items) {
+    console.log('Polymer got splice', arguments);
+  };
+
+  this.notifyPath = function() {
+    console.log('Polymer got notifyPath', arguments);
+  };
+
+};
+
+describe("Array modification through Polymer splices, emulate backbone events", function() {
+
+  describe("Backbone events before backbone-polymer", function() {
+
+    it("add model", function() {
+      var c = new Backbone.Collection();
+      var m = new Backbone.Model({id: 'a1', type: 'testmodel'})
+      c.on('add', function(model, collection, options) {
+        console.log('add', m === model ? '(model)' : model, c === collection ? '(collection)' : collection, JSON.stringify(options));
+      });
+      c.add(m);
+    });
+
+    it("add model at index", function() {
+      var c = new Backbone.Collection();
+      c.add({id: 'a2', type: 'testmodel2'});
+      c.add({id: 'a3', type: 'testmodel3'});
+      var m = new Backbone.Model({id: 'a1', type: 'testmodel'})
+      c.on('add', function(model, collection, options) {
+        console.log('add', m === model ? '(model)' : model, c === collection ? '(collection)' : collection, JSON.stringify(options));
+      });
+      var added = c.add(m, {at: 1});
+      console.log('add returned', m === added ? '(model)' : model);
+    });
+
+  });
+
+  describe("#add", function() {
+
+    it("Is transparent to backbone add event listener", function() {
+      var e = new PolymerElementMock();
+      var c = new Backbone.Collection();
+      var adds = [];
+      c.on('add', function() { adds.push(arguments); });
+      BackbonePolymerAttach.call(c, e, 'edit.units');
+      var m = c.add(new Backbone.Model({id: 'add1', type: 'test'}));
+      expect(m.get('type')).to.equal('test');
+      expect(adds).to.have.length(1);
+    });
+
+  });
+
+});

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -8,12 +8,15 @@ var Backbone = require('yobo').Backbone;
 
 var BackbonePolymerAttach = require('../backbone-polymer-mixin');
 
-var PolymerElementMock = function() {
+var PolymerElementMock = function(testArray) {
 
   var spliced = this.spliced = [];
 
   this.splice = function(path, index, removeCount, items) {
     spliced.push({path: path, index: index, removeCount: removeCount, items: items});
+    if (typeof testArray !== 'undefined') {
+      testArray.splice.apply(testArray, [index, removeCount].concat(items));
+    }
   };
 
   this.notifyPath = function() {
@@ -84,8 +87,8 @@ describe("Array modification through Polymer splices, emulate backbone events", 
     });
 
     it("Is transparent to backbone add event listener", function() {
-      var e = new PolymerElementMock();
       var c = new Backbone.Collection();
+      var e = new PolymerElementMock(c.models);
 
       var adds = [];
       c.on('add', function(m, c, o) {

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -71,12 +71,35 @@ describe("Array modification through Polymer splices, emulate backbone events", 
       var e = new PolymerElementMock();
       var c = new Backbone.Collection();
       var adds = [];
+
       c.on('add', function() { adds.push(arguments); });
       BackbonePolymerAttach.call(c, e, 'edit.units');
       var m = c.add(new Backbone.Model({id: 'add1', type: 'test'}));
+
       expect(m.get('type')).to.equal('test');
       expect(adds).to.have.length(1);
       expect(e.spliced).to.have.length(1);
+
+      //Expects on the options obj.
+      expect(adds[0][2]).to.be.an('object');
+      expect(adds[0][2]).to.have.property('add').and.equal(true);
+      expect(adds[0][2]).to.have.property('merge').and.equal(false);
+      expect(adds[0][2]).to.have.property('remove').and.equal(false);
+
+      var m1 = new Backbone.Model({id: 'add2', type: 'test'});
+      c.add(m1, {at: 1});
+
+      //Adding at an index, expects Options to have 'at'
+      expect(adds[1][2]).to.have.property('add').and.equal(true);
+      expect(adds[1][2]).to.have.property('at').and.equal(1);
+      expect(e.spliced).to.have.length(2);
+
+      //Adding again at index 2
+      var m2 = new Backbone.Model({id: 'add3', type: 'test'});
+      c.add(m2, {at: 2});
+      
+      expect(e.spliced[2]).to.have.property('index').and.equal(2);
+
     });
 
   });

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -131,6 +131,7 @@ describe("Array modification through Polymer splices, emulate backbone events", 
 
       // common Backbone operations
       expect(c.get('add1')).to.exist.and.have.property('cid');
+      expect(c.models).to.have.length(3);
       expect(c.at(1)).to.exist.and.have.property('cid');
     });
   });

--- a/test/backbone-emulated-events-spec.js
+++ b/test/backbone-emulated-events-spec.js
@@ -44,6 +44,22 @@ describe("Array modification through Polymer splices, emulate backbone events", 
 
   describe("#add", function() {
 
+    it("ATM accepts only a single item", function() {
+      expect(function() {
+        var c = new Backbone.Collection();
+        BackbonePolymerAttach.call(c, new PolymerElementMock(), 'edit.units');
+        c.add([]);
+      }).to.throw(/single/);
+    });
+
+    it("ATM requires that item to be a real model", function() {
+      expect(function() {
+        var c = new Backbone.Collection();
+        BackbonePolymerAttach.call(c, new PolymerElementMock(), 'edit.units');
+        c.add({id: 'add1', type: 'test'});
+      }).to.throw(/requires model instance/);
+    });
+
     it("Is transparent to backbone add event listener", function() {
       var e = new PolymerElementMock();
       var c = new Backbone.Collection();

--- a/test/test.html
+++ b/test/test.html
@@ -85,7 +85,7 @@
 
         });
 
-        it("Uses 'this' for the collection, like a regular Backbone member function", function(done) {
+        it("Can be used with .call instead of as mixin", function(done) {
 
           var element1 = document.querySelector('#collection1');
 

--- a/test/test.html
+++ b/test/test.html
@@ -106,7 +106,7 @@
           expect(renderTimeAllowMs).to.be.at.least(2); // the sequence below is fragile, and there's a timeout in the notification too
 
           window.setTimeout(function() {
-            m1 = c1.add({type: 'text', content: 'As added after setup.'});
+            m1 = c1.add(new Backbone.Model({type: 'text', content: 'As added after setup.'}));
           }, renderTimeAllowMs);
 
           window.setTimeout(function() {


### PR DESCRIPTION
This fix avoids overriding the elaborate Collection.set method in Backbone, but is on the other hand severely restricted on the types of add operations it allows.

For a generic solution we should work on #5. Ideally Backbone would expose Collection's internal `splice` method for overriding.
